### PR TITLE
Trigger notifications after GF cache cleared

### DIFF
--- a/gravityview-enable-notifications.php
+++ b/gravityview-enable-notifications.php
@@ -3,14 +3,14 @@
 * Plugin Name:       	GravityView - Enable Gravity Forms Notifications
 * Plugin URI:        	http://gravityview.co/
 * Description:       	Enable Gravity Forms notifications when an entry is edited in GravityView.
-* Version:          	1.0
+* Version:          	1.0.1
 * Author:            	Katz Web Services, Inc.
 * Author URI:        	http://www.katzwebservices.com
 * License:           	GPLv2 or later
 * License URI: 			http://www.gnu.org/licenses/gpl-2.0.html
 */
 
-add_action( 'gform_after_update_entry', 'gravityview_enable_gf_notifications_after_update', 10, 2 );
+add_action( 'gravityview/edit_entry/after_update', 'gravityview_enable_gf_notifications_after_update', 20, 2 );
 
 /**
  * Triggers Gravity Forms notifications engine when entry is updated (admin or frontend)


### PR DESCRIPTION
The products cache doesn't get cleared until priority 10 of `gravityview/edit_entry/after_update`, which is well after when the original `gform_after_update_entry` action was fired. This led to notifications (and in my case PDFs) that had out-of-date product details. This change will ensure the notifications aren't fired until after the products cache is cleared.